### PR TITLE
feat: disable all MCP tools except searchDesignSystem

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,8 @@
 import { searchDesignSystemTool } from "./searchDesignSystem";
-import { getComponentPropertiesTool } from "./getComponentProperties";
-import { getComponentExamplesTool } from "./getComponentExamples";
-import { listComponentsTool } from "./listComponents";
+// Temporarily disabled imports - keeping for future use
+// import { getComponentPropertiesTool } from "./getComponentProperties";
+// import { getComponentExamplesTool } from "./getComponentExamples";
+// import { listComponentsTool } from "./listComponents";
 import type { ToolDefinition } from "../types";
 
 /**
@@ -54,7 +55,8 @@ import type { ToolDefinition } from "../types";
  */
 export const tools: ToolDefinition[] = [
 	searchDesignSystemTool,
-	getComponentPropertiesTool,
-	getComponentExamplesTool,
-	listComponentsTool,
+	// Temporarily disabled - keeping code for future use
+	// getComponentPropertiesTool,
+	// getComponentExamplesTool,
+	// listComponentsTool,
 ];


### PR DESCRIPTION
Temporarily disabled getComponentProperties, getComponentExamples, and listComponents tools. Only searchDesignSystem remains active. Code for disabled tools is preserved for future use.

🤖 Generated with [Claude Code](https://claude.ai/code)