### PR TITLE
fix: clarify refreshStatus tracks R2 bucket updates, not AutoRAG rein…

### DIFF
--- a/sync-utility/src/lib/kv-tracker.ts
+++ b/sync-utility/src/lib/kv-tracker.ts
@@ -1,0 +1,73 @@
+/**
+ * KV Tracker for Recording R2 Sync Timestamps
+ *
+ * Records when the R2 bucket was last updated with fresh documentation
+ * from GitHub. This timestamp is used by the refreshStatus MCP tool.
+ */
+
+import { spawn } from 'node:child_process';
+
+/**
+ * Record sync completion timestamp in KV namespace
+ *
+ * @param autoragId - Identifier for the AutoRAG instance (default: "vads-rag-mcp")
+ * @returns Success status and any error message
+ */
+export async function recordSyncTimestamp(
+	autoragId: string = 'vads-rag-mcp',
+): Promise<{ success: boolean; error?: string }> {
+	try {
+		const timestamp = Date.now().toString();
+		const key = `last-refresh:${autoragId}`;
+
+		// Use wrangler CLI to write to KV
+		await wranglerKVPut(key, timestamp);
+
+		return { success: true };
+	} catch (error) {
+		return {
+			success: false,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
+/**
+ * Write a value to KV using wrangler CLI
+ */
+async function wranglerKVPut(key: string, value: string): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const args = [
+			'kv',
+			'key',
+			'put',
+			'--namespace-id=680e786a6dda42b3a41ed48ae74edb0d',
+			'--remote',
+			key,
+			value,
+		];
+
+		const wrangler = spawn('npx', ['wrangler', ...args], {
+			stdio: 'pipe',
+			cwd: process.cwd(),
+		});
+
+		let stderr = '';
+
+		wrangler.stderr?.on('data', (data) => {
+			stderr += data.toString();
+		});
+
+		wrangler.on('close', (code) => {
+			if (code === 0) {
+				resolve();
+			} else {
+				reject(new Error(`Wrangler KV put failed (code ${code}): ${stderr}`));
+			}
+		});
+
+		wrangler.on('error', (error) => {
+			reject(error);
+		});
+	});
+}

--- a/sync-utility/wrangler.jsonc
+++ b/sync-utility/wrangler.jsonc
@@ -1,8 +1,9 @@
 /**
  * Wrangler configuration for VA Docs Sync Utility
  *
- * This utility uses the same R2 bucket as the main MCP server.
- * It only needs R2 access to upload markdown files.
+ * This utility uses the same R2 bucket and KV namespace as the main MCP server.
+ * - R2: To upload markdown files
+ * - KV: To record sync timestamps for refreshStatus tool
  */
 {
 	"$schema": "node_modules/wrangler/config-schema.json",
@@ -13,6 +14,13 @@
 		{
 			"binding": "VADS_DOCS",
 			"bucket_name": "vads-docs"
+		}
+	],
+	"kv_namespaces": [
+		{
+			"binding": "REFRESH_TRACKER",
+			"id": "680e786a6dda42b3a41ed48ae74edb0d",
+			"preview_id": "9cfd112f8d534d80b4af49edfc8f97a2"
 		}
 	]
 }


### PR DESCRIPTION
…dexing

- Update refreshStatus tool documentation to clearly indicate it tracks R2 bucket updates
- Rename messaging from "Manual Refresh" to "R2 Update" for clarity
- Add kv-tracker.ts to record sync timestamps when sync-utility completes
- Update sync-utility to record timestamp in KV after successful sync
- Add REFRESH_TRACKER KV namespace to sync-utility wrangler config
- Separate R2 updates from AutoRAG auto-reindexing in status messages

This fixes confusion where users thought the tool tracked AutoRAG reindexing. The tool actually tracks when the R2 bucket was last updated with fresh documentation from GitHub using the sync-utility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)